### PR TITLE
Update BartecService so that caching is optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,33 @@
 
 ## Usage
 
+### Bartec Client Usage
+```
+/** BartecClient $bartecClient **/
+$bartecClient = new BartecClient(
+    new SoapClient(BartecClient::WSDL_AUTH),
+    new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
+    'BARTEC_API_USERNAME',
+    'BARTEC_API_PASSWORD'
+);
+```
+### Bartec Service Usage
+
+```
+/** @var BartecService $bartecService */
+$bartecService = new BartecService(
+    $bartecClient,  // instance of BartecClient
+    new FilesystemAdapter('Tests-functional-Service', BartecService::CACHE_LIFETIME)  // Optional PSR-6 cache library
+);
+
+```
+
 See [example.php](example.php)
 
 ## Tests
 
-Unit Tests
+Update [BartecServiceTest](tests/functional/Service/BartecServiceTest.php) with API credentials
+
+Run Unit and Functional Tests
  
 `./vendor/bin/phpunit tests`

--- a/example.php
+++ b/example.php
@@ -47,7 +47,7 @@ try {
 /** @var BartecService $bartecService */
 $bartecService = new BartecService(
     $bartecClient,
-    new FilesystemAdapter('Tests-functional-Service', BartecService::CACHE_LIFETIME) // Any cache library implementing Psr\Cache\CacheItemPoolInterface
+    new FilesystemAdapter('Tests-functional-Service', BartecService::CACHE_LIFETIME) // OPTIONAL: Any cache library implementing Psr\Cache\CacheItemPoolInterface
 );
 
 // optional for debugging


### PR DESCRIPTION
- Cache parameter is now optional in [BartecService](https://github.com/LBHounslow/bartec/blob/develop/src/Service/BartecService.php#L36).
- All cached methods now [check if caching is set](https://github.com/LBHounslow/bartec/blob/develop/src/Service/BartecService.php#L224).
- Cache keys should be [generated](https://github.com/LBHounslow/bartec/blob/develop/src/Service/BartecService.php#L1029), this includes a [namespace](https://github.com/LBHounslow/bartec/blob/develop/src/Service/BartecService.php#L20) so they are unique to this library.

Passing tests:
```
bartec % ./vendor/bin/phpunit tests
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

................................................................. 65 / 68 ( 95%)
...                                                               68 / 68 (100%)

Time: 14.66 seconds, Memory: 54.00 MB

OK (68 tests, 130 assertions)
```