### PR TITLE
Prefixed namespace with LBHounslow to avoid conflicts with other packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Bartec\\": "src/"
+      "LBHounslow\\Bartec\\": "src/"
     }
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -155,16 +155,16 @@
         },
         {
             "name": "symfony/cache",
-            "version": "v5.3.8",
+            "version": "v5.3.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/cache.git",
-                "reference": "945bcebfef0aeef105de61843dd14105633ae38f"
+                "reference": "2056f2123f47c9f63102a8b92974c362f4fba568"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/945bcebfef0aeef105de61843dd14105633ae38f",
-                "reference": "945bcebfef0aeef105de61843dd14105633ae38f",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/2056f2123f47c9f63102a8b92974c362f4fba568",
+                "reference": "2056f2123f47c9f63102a8b92974c362f4fba568",
                 "shasum": ""
             },
             "require": {
@@ -232,7 +232,7 @@
                 "psr6"
             ],
             "support": {
-                "source": "https://github.com/symfony/cache/tree/v5.3.8"
+                "source": "https://github.com/symfony/cache/tree/v5.3.10"
             },
             "funding": [
                 {
@@ -248,7 +248,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-26T18:29:18+00:00"
+            "time": "2021-10-11T15:41:55+00:00"
         },
         {
             "name": "symfony/cache-contracts",
@@ -1005,16 +1005,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -1025,7 +1025,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -1055,9 +1056,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",

--- a/example.php
+++ b/example.php
@@ -1,11 +1,11 @@
 <?php
 require_once 'vendor/autoload.php';
 
-use Bartec\Exception\SoapException;
-use Bartec\Client\Client as BartecClient;
-use Bartec\Client\SoapClient;
-use Bartec\Response\Response;
-use Bartec\Service\BartecService;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Client\Client as BartecClient;
+use LBHounslow\Bartec\Client\SoapClient;
+use LBHounslow\Bartec\Response\Response;
+use LBHounslow\Bartec\Service\BartecService;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 // BARTEC CLIENT USAGE

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Bartec\Client;
+namespace LBHounslow\Bartec\Client;
 
-use Bartec\Exception\SoapException;
-use Bartec\Response\Response;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
 
 class Client
 {

--- a/src/Client/SoapClient.php
+++ b/src/Client/SoapClient.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Bartec\Client;
+namespace LBHounslow\Bartec\Client;
 
-use Bartec\Response\SoapResponse;
+use LBHounslow\Bartec\Response\SoapResponse;
 
 /**
  * SOAP Client

--- a/src/Enum/BartecServiceEnum.php
+++ b/src/Enum/BartecServiceEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bartec\Enum;
+namespace LBHounslow\Bartec\Enum;
 
 class BartecServiceEnum
 {

--- a/src/Enum/DateEnum.php
+++ b/src/Enum/DateEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bartec\Enum;
+namespace LBHounslow\Bartec\Enum;
 
 class DateEnum
 {

--- a/src/Exception/SoapException.php
+++ b/src/Exception/SoapException.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Bartec\Exception;
+namespace LBHounslow\Bartec\Exception;
 
-use Bartec\Response\Response;
+use LBHounslow\Bartec\Response\Response;
 use Throwable;
 
 class SoapException extends \Exception

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bartec\Response;
+namespace LBHounslow\Bartec\Response;
 
 class Response extends SoapResponse
 {

--- a/src/Response/SoapResponse.php
+++ b/src/Response/SoapResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bartec\Response;
+namespace LBHounslow\Bartec\Response;
 
 /**
  * SOAP Response

--- a/src/Service/BartecService.php
+++ b/src/Service/BartecService.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Bartec\Service;
+namespace LBHounslow\Bartec\Service;
 
-use Bartec\Client\Client as BartecClient;
-use Bartec\Enum\BartecServiceEnum;
-use Bartec\Exception\SoapException;
-use Bartec\Response\Response;
+use LBHounslow\Bartec\Client\Client as BartecClient;
+use LBHounslow\Bartec\Enum\BartecServiceEnum;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Cache\InvalidArgumentException;

--- a/tests/functional/Service/BartecServiceTest.php
+++ b/tests/functional/Service/BartecServiceTest.php
@@ -2,13 +2,13 @@
 
 namespace Tests\Functional\Service;
 
-use Bartec\Client\Client as BartecClient;
-use Bartec\Client\SoapClient;
-use Bartec\Enum\BartecServiceEnum;
-use Bartec\Enum\DateEnum;
-use Bartec\Exception\SoapException;
-use Bartec\Response\Response;
-use Bartec\Service\BartecService;
+use LBHounslow\Bartec\Client\Client as BartecClient;
+use LBHounslow\Bartec\Client\SoapClient;
+use LBHounslow\Bartec\Enum\BartecServiceEnum;
+use LBHounslow\Bartec\Enum\DateEnum;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
+use LBHounslow\Bartec\Service\BartecService;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use Tests\functional\BartecTestCase;
 

--- a/tests/unit/Client/ClientTest.php
+++ b/tests/unit/Client/ClientTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Unit\Client;
 
-use Bartec\Client\Client as BartecClient;
-use Bartec\Client\SoapClient;
-use Bartec\Exception\SoapException;
-use Bartec\Response\Response;
-use Bartec\Response\SoapResponse;
+use LBHounslow\Bartec\Client\Client as BartecClient;
+use LBHounslow\Bartec\Client\SoapClient;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
+use LBHounslow\Bartec\Response\SoapResponse;
 use Tests\Unit\BartecTestCase;
 
 class ClientTest extends BartecTestCase

--- a/tests/unit/Client/SoapClientTest.php
+++ b/tests/unit/Client/SoapClientTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Client;
 
-use Bartec\Client\SoapClient;
+use LBHounslow\Bartec\Client\SoapClient;
 use Tests\Unit\BartecTestCase;
 
 class SoapClientTest extends BartecTestCase

--- a/tests/unit/Exception/SoapExceptionTest.php
+++ b/tests/unit/Exception/SoapExceptionTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Exception;
 
-use Bartec\Exception\SoapException;
-use Bartec\Response\Response;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
 use Tests\Unit\BartecTestCase;
 
 class SoapExceptionTest extends BartecTestCase

--- a/tests/unit/Response/ResponseTest.php
+++ b/tests/unit/Response/ResponseTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Tests\Unit\Soap\Response;
+namespace Tests\Unit\Response;
 
-use Bartec\Response\Response;
-use Bartec\Response\SoapResponse;
+use LBHounslow\Bartec\Response\Response;
+use LBHounslow\Bartec\Response\SoapResponse;
 use Tests\Unit\BartecTestCase;
 
 class ResponseTest extends BartecTestCase

--- a/tests/unit/Response/SoapResponseTest.php
+++ b/tests/unit/Response/SoapResponseTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Tests\Unit\Soap\Response;
+namespace Tests\Unit\Response;
 
-use Bartec\Response\SoapResponse;
+use LBHounslow\Bartec\Response\SoapResponse;
 use Tests\Unit\BartecTestCase;
 
 class SoapResponseTest extends BartecTestCase


### PR DESCRIPTION
Added `LBHounslow` prefix to all namespaces to avoid any conflicts with other Bartec packages.

```
bartec % ./vendor/bin/phpunit tests                                 
PHPUnit 8.5.21 by Sebastian Bergmann and contributors.

................................................................. 65 / 68 ( 95%)
...                                                               68 / 68 (100%)

Time: 33.7 seconds, Memory: 68.00 MB

OK (68 tests, 130 assertions)
```