### PR TITLE
Hotfix - Added getFeatureSchedules to the BartecService

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 vendor/*
+.phpunit.cache/*
 .idea/*
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,16 @@ Run all tests
  
 `composer test`
 
+```
+Code Coverage Report:      
+  2021-12-29 08:54:20      
+                           
+ Summary:                  
+  Classes: 33.33% (2/6)    
+  Methods: 51.28% (40/78)  
+  Lines:   73.63% (335/455)
+```
+
 ### Contributing
 
 This repository is currently closed for contribution. Please [report an an issue](https://github.com/LBHounslow/bartec/issues) if you come across one.

--- a/README.md
+++ b/README.md
@@ -1,45 +1,31 @@
-# London Borough of Hounslow
+## London Borough of Hounslow - Bartec Collective
 
-#### A client for the [Bartec Collective API v15](https://confluence.bartecautoid.com/display/COLLAPIR15/) SOAP Web  Service
+#### A client and service for the [Bartec Collective API v15](https://confluence.bartecautoid.com/display/COLLAPIR15/) SOAP Web Service
+
+For more on how to use this client, see [usage documentation](docs/USAGE.md)
+
+### Releases
+
+- These are covered in [the Changelog](docs/CHANGELOG.md)
 
 ## Requirements
 
-- PHP 7.4.2+
-- Required extensions: [SOAP](https://www.php.net/manual/en/soap.installation.php), [Json](https://www.php.net/manual/en/json.installation.php)
+- [PHP 7.4.2+](https://www.php.net/downloads.php)
+- [Git](https://git-scm.com/downloads)
+- [Composer](https://getcomposer.org)
 
 ## Setup
 
 - `composer install`
 
-## Usage
-
-### Bartec Client Usage
-```
-/** BartecClient $bartecClient **/
-$bartecClient = new BartecClient(
-    new SoapClient(BartecClient::WSDL_AUTH),
-    new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
-    'BARTEC_API_USERNAME',
-    'BARTEC_API_PASSWORD'
-);
-```
-### Bartec Service Usage
-
-```
-/** @var BartecService $bartecService */
-$bartecService = new BartecService(
-    $bartecClient,  // instance of BartecClient
-    new FilesystemAdapter('Tests-functional-Service', BartecService::CACHE_LIFETIME)  // Optional PSR-6 cache library
-);
-
-```
-
-See [example.php](example.php)
-
 ## Tests
 
-Update [BartecServiceTest](tests/functional/Service/BartecServiceTest.php) with API credentials
+Update [BartecServiceTest](tests/functional/Service/BartecServiceTest.php) with your Bartec TEST API credentials
 
-Run Unit and Functional Tests
+Run all tests
  
-`./vendor/bin/phpunit tests`
+`composer test`
+
+### Contributing
+
+This repository is currently closed for contribution. Please [report an an issue](https://github.com/LBHounslow/bartec/issues) if you come across one.

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "ext-json": "*",
     "ext-soap": "*",
     "psr/cache": "^1.0",
-    "symfony/cache": "^5.3"
+    "symfony/cache": "^5.4"
   },
   "autoload": {
     "psr-4": {
@@ -17,12 +17,16 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Tests\\": "tests/",
       "Tests\\Unit\\": "tests/unit/",
       "Tests\\Functional\\": "tests/functional/"
     }
   },
+  "scripts": {
+    "test": [
+      "./vendor/bin/phpunit tests --colors"
+    ]
+  },
   "require-dev": {
-    "phpunit/phpunit": "^8.5.2"
+    "phpunit/phpunit": "^9.5"
   }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Release v1.5 `28/12/2021`
 
-- Added getFeatureSchedules to the BartecService along with functional test coverage.
-- Updated `phpunit.xml.dist` and added script to composer.json to run all tests using `composer test`
+- Added [getFeatureSchedules](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/src/Service/BartecService.php#L940) to the BartecService along with [functional test coverage](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L570).
+- Updated [phpunit.xml.dist](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/phpunit.xml.dist#L1) and added [script to composer.json](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/composer.json#L25) to run all tests using `composer test`
 
 Fixes:
-- Corrected namespace case issue in BartecServiceTest.
+- Corrected namespace [case issue](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L12) in BartecServiceTest.
 
 ### Release v1.4 `05/11/2021`
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,39 @@
+## London Borough of Hounslow - Bartec Collective
+
+## Changelog
+
+### Release v1.5 `28/12/2021`
+
+- Added getFeatureSchedules to the BartecService along with functional test coverage.
+- Updated `phpunit.xml.dist` and added script to composer.json to run all tests using `composer test`
+
+Fixes:
+- Corrected namespace case issue in BartecServiceTest.
+
+### Release v1.4 `05/11/2021`
+
+- Changed namespace throughout to include the prefix [LBHounslow\Bartec](https://github.com/LBHounslow/bartec/blob/v1.4/composer.json#L15) to be consistent with other lb-hounslow packages.
+
+### Release v1.3 `19/09/2021`
+
+- Updated the [BartecService PSR cache argument](https://github.com/LBHounslow/bartec/blob/v1.3/src/Service/BartecService.php#L36) to be **optional**. Updated methods to check for existence of cache.
+
+### Release v1.2 `13/09/2021`
+
+Updates:
+- Upgrade PHP version from 7.2 to 7.4.2.
+- The Hounslow API and Jadu XFP Custom Bundle were using 2 variations of a BartecService. I have consolidated these into the [BartecService](https://github.com/LBHounslow/bartec/blob/v1.2/src/Service/BartecService.php#L17) (added to this library) so that both applications can use one service. _It will allow us to add functional test coverage in preparation for the v16 upgrade._
+- Added [BartecServiceEnum](https://github.com/LBHounslow/bartec/blob/v1.2/src/Enum/BartecServiceEnum.php#L5) which is used by the Bartec Service. This service [requires a PSR cache](https://github.com/LBHounslow/bartec/blob/v1.2/src/Service/BartecService.php#L33) to be passed into the constructor.
+- Added [functional test coverage](https://github.com/LBHounslow/bartec/blob/v1.2/tests/functional/Service/BartecServiceTest.php#L15) for the BartecService.
+- Updated [usage documentation](https://github.com/LBHounslow/bartec/blob/v1.2/example.php#L46) in example.php
+
+Fixes:
+- Added [check before overriding](https://github.com/LBHounslow/bartec/blob/v1.2/src/Client/Client.php#L66) both `SoapClient` options so that we don't always override with empty options.
+
+### Release v1.1 `01/03/2021`
+
+- Added [soapOptions](https://github.com/LBHounslow/bartec/blob/v1.1/src/Client/Client.php#L43) argument and [setSoapOptions](https://github.com/LBHounslow/bartec/blob/v1.1/src/Client/Client.php#L88) method so that we can override options for both `SoapClient` arguments.
+
+### Release v1.0 `20/04/2020`
+
+Initial application layout.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Changelog
 
-### Release v1.5 `28/12/2021`
+### Release v1.5 `29/12/2021`
 
 - Added [getFeatureSchedules](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/src/Service/BartecService.php#L940) to the BartecService along with [functional test coverage](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L570).
 - Updated [phpunit.xml.dist](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/phpunit.xml.dist#L1) and added [script to composer.json](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/composer.json#L25) to run all tests using `composer test`
+- Added [CHANGELOG](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/docs/CHANGELOG.md) and moved usage to [USAGE](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/docs/USAGE.md) docs. Added phpunit code [test coverage report to README](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/README.md?plain=1#L30).
 
 Fixes:
-- Corrected namespace [case issue](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L12) in BartecServiceTest.
+- Corrected namespace [case issue](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L12) in `BartecServiceTest` and `BartecTestCase`.
 
 ### Release v1.4 `05/11/2021`
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,29 @@
+## London Borough of Hounslow - Bartec Collective
+
+## Usage
+
+
+### Bartec Client Usage
+```
+/** BartecClient $bartecClient **/
+$bartecClient = new BartecClient(
+    new SoapClient(BartecClient::WSDL_AUTH),
+    new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
+    'BARTEC_API_USERNAME',
+    'BARTEC_API_PASSWORD',
+    ['trace' => 1] // optional for debugging
+);
+```
+
+### Bartec Service Usage
+
+```
+/** @var BartecService $bartecService */
+$bartecService = new BartecService(
+    $bartecClient,  // instance of BartecClient
+    new FilesystemAdapter('Tests-functional-Service', BartecService::CACHE_LIFETIME)  // Optional PSR-6 cache library
+);
+
+```
+
+See [example.php](example.php)

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
-<phpunit bootstrap = "vendor/autoload.php"
-         backupGlobals               = "false"
-         backupStaticAttributes      = "false"
-         colors                      = "true"
-         convertErrorsToExceptions   = "true"
-         convertNoticesToExceptions  = "true"
-         convertWarningsToExceptions = "true"
-         processIsolation            = "false"
-         stopOnFailure               = "false">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         cacheResultFile=".phpunit.cache/test-results"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         convertDeprecationsToExceptions="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
     <testsuites>
-        <testsuite name="Project Test Suite">
+        <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <coverage cacheDirectory=".phpunit.cache/code-coverage"
+              processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Service/BartecService.php
+++ b/src/Service/BartecService.php
@@ -934,6 +934,25 @@ class BartecService
 
     /**
      * @param string $UPRN
+     * @return mixed|null
+     * @throws SoapException
+     */
+    public function getFeatureSchedules(string $UPRN)
+    {
+        $response = $this->client->call(
+            'Features_Schedules_Get',
+            ['UPRN' => $UPRN, 'Types' => '']
+        );
+
+        if ($response->hasErrors()) {
+            throw new SoapException($response);
+        }
+
+        return $response->getResult();
+    }
+
+    /**
+     * @param string $UPRN
      * @param array $featureTypeNames
      * @param array $featureStates
      * @param bool $includeRelated

--- a/tests/functional/BartecTestCase.php
+++ b/tests/functional/BartecTestCase.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests\functional;
+namespace Tests\Functional;
 
 use PHPUnit\Framework\TestCase;
 

--- a/tests/functional/Service/BartecServiceTest.php
+++ b/tests/functional/Service/BartecServiceTest.php
@@ -9,8 +9,7 @@ use LBHounslow\Bartec\Enum\DateEnum;
 use LBHounslow\Bartec\Exception\SoapException;
 use LBHounslow\Bartec\Response\Response;
 use LBHounslow\Bartec\Service\BartecService;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
-use Tests\functional\BartecTestCase;
+use Tests\Functional\BartecTestCase;
 
 class BartecServiceTest extends BartecTestCase
 {
@@ -26,9 +25,10 @@ class BartecServiceTest extends BartecTestCase
                 new SoapClient(BartecClient::WSDL_AUTH),
                 new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
                 'BARTEC_API_USERNAME',
-                'BARTEC_API_PASSWORD'
-            ),
-            new FilesystemAdapter('Tests-functional-Service', BartecService::CACHE_LIFETIME)
+                'BARTEC_API_PASSWORD',
+                ['trace' => 1]
+            )
+            // no cache passed for testing
         );
         parent::setUp();
     }
@@ -565,6 +565,15 @@ class BartecServiceTest extends BartecTestCase
         $this->assertTrue(isset($result->FeatureType));
         $this->assertIsArray($result->FeatureType);
         $this->assertTrue(isset($result->FeatureType[0]->ID));
+    }
+
+    public function testItGetFeatureSchedules()
+    {
+        /** @var \stdClass $result */
+        $result = $this->bartecService->getFeatureSchedules(self::RESIDENTIAL_UPRN);
+        $this->assertTrue(isset($result->FeatureSchedule));
+        $this->assertIsArray($result->FeatureSchedule);
+        $this->assertTrue(isset($result->FeatureSchedule[0]->ID));
     }
 
     /**


### PR DESCRIPTION
- Added [getFeatureSchedules](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/src/Service/BartecService.php#L940) to the BartecService along with [functional test coverage](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L570).
- Updated [phpunit.xml.dist](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/phpunit.xml.dist#L1) and added [script to composer.json](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/composer.json#L25) to run all tests using `composer test`
- Added [CHANGELOG](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/docs/CHANGELOG.md) and moved usage to [USAGE](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/docs/USAGE.md) docs. Added phpunit code [test coverage report to README](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/README.md?plain=1#L30).

Fixes:
- Corrected namespace [case issue](https://github.com/LBHounslow/bartec/blob/hotfix-get-feature-schedules/tests/functional/Service/BartecServiceTest.php#L12) in `BartecServiceTest` and `BartecTestCase`.

```
bartec % ./vendor/bin/phpunit tests --colors
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.25 with Xdebug 3.1.1
Configuration: /Users/brett/Code/bartec/phpunit.xml.dist

................................................................. 65 / 69 ( 94%)
....                                                              69 / 69 (100%)

Time: 00:23.446, Memory: 92.00 MB

OK (69 tests, 133 assertions)

# NOTE: The v15 test environment no longer exists (it has been replaced with v16). These tests were run against the v16 WSDL.
```