### PR TITLE
APID-40 - Bartec Collective API Upgrade to v16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 ## London Borough of Hounslow - Bartec Collective
 
-#### A client and service for the [Bartec Collective API v15](https://confluence.bartecautoid.com/display/COLLAPIR15/) SOAP Web Service
+#### A library for the [Bartec Collective](https://www.bartecmunicipal.com/software/collective/) SOAP Web Service
+
+This library includes both a [Client](src/Client/Client.php) and a [BartecService](src/Service/BartecService.php). The library can be used with [v15](https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx?WSDL) or [v16](https://collectiveapi.bartec-systems.com/API-R1604/CollectiveAPI.asmx?WSDL) of the Bartec Collective.
+
+The [BartecService](src/Service/BartecService.php) has several methods that are used regularly by LBHounslow which you are free to use. For any other call you can use the [Client](src/Client/Client.php) directly.
 
 For more on how to use this client, see [usage documentation](docs/USAGE.md)
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "lb-hounslow/bartec",
-  "description": "A client and basic service for the Bartec Collective API v15 SOAP Web Service",
+  "description": "A library for the Bartec Collective API SOAP Web Service",
   "type": "library",
   "license": "proprietary",
   "require": {

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -8,7 +8,7 @@
 /** BartecClient $bartecClient **/
 $bartecClient = new BartecClient(
     new SoapClient(BartecClient::WSDL_AUTH),
-    new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
+    new SoapClient(Version16Adapter::WSDL_COLLECTIVE_API),
     'BARTEC_API_USERNAME',
     'BARTEC_API_PASSWORD',
     ['trace' => 1] // optional for debugging
@@ -21,7 +21,7 @@ $bartecClient = new BartecClient(
 /** @var BartecService $bartecService */
 $bartecService = new BartecService(
     $bartecClient,              // instance of BartecClient
-    Version15Adapter::VERSION,  // version to use (v15 or v16)
+    Version16Adapter::VERSION,  // version to use (v15 or v16)
     // Optional PSR-6 cache library
 );
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -20,7 +20,8 @@ $bartecClient = new BartecClient(
 ```
 /** @var BartecService $bartecService */
 $bartecService = new BartecService(
-    $bartecClient,  // instance of BartecClient
+    $bartecClient,              // instance of BartecClient
+    Version15Adapter::VERSION,  // version to use (v15 or v16)
     // Optional PSR-6 cache library
 );
 

--- a/example.php
+++ b/example.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'vendor/autoload.php';
 
-use LBHounslow\Bartec\Adapter\Version15Adapter;
+use LBHounslow\Bartec\Adapter\Version16Adapter;
 use LBHounslow\Bartec\Client\Client as BartecClient;
 use LBHounslow\Bartec\Client\SoapClient;
 use LBHounslow\Bartec\Exception\SoapException;
@@ -11,7 +11,7 @@ use LBHounslow\Bartec\Service\BartecService;
 // BARTEC CLIENT USAGE
 $bartecClient = new BartecClient(
     new SoapClient(BartecClient::WSDL_AUTH),
-    new SoapClient(Version15Adapter::WSDL_COLLECTIVE_API), // v15
+    new SoapClient(Version16Adapter::WSDL_COLLECTIVE_API), // v16
     'BARTEC_API_USERNAME',
     'BARTEC_API_PASSWORD'
 );
@@ -47,13 +47,13 @@ try {
 /** @var BartecService $bartecService */
 $bartecService = new BartecService(
     $bartecClient,
-    Version15Adapter::VERSION // v15
+    Version16Adapter::VERSION // v16
     // OPTIONAL: Any cache library implementing Psr\Cache\CacheItemPoolInterface
 );
 
 // optional for debugging
-// $bartecService->setClientSoapOptions(['connection_timeout' => 20, 'trace' => 1]);
-// $debugInfo = $bartecService->getClient()->getCollectiveSoapClient()->getDebugInfo();
+ $bartecService->setClientSoapOptions(['connection_timeout' => 20, 'trace' => 1]);
+ $debugInfo = $bartecService->getClient()->getCollectiveSoapClient()->getDebugInfo();
 
 /** @var Response $response */
 $response = $bartecService->getServiceRequestClasses();

--- a/example.php
+++ b/example.php
@@ -1,16 +1,17 @@
 <?php
 require_once 'vendor/autoload.php';
 
-use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Adapter\Version15Adapter;
 use LBHounslow\Bartec\Client\Client as BartecClient;
 use LBHounslow\Bartec\Client\SoapClient;
+use LBHounslow\Bartec\Exception\SoapException;
 use LBHounslow\Bartec\Response\Response;
 use LBHounslow\Bartec\Service\BartecService;
 
 // BARTEC CLIENT USAGE
 $bartecClient = new BartecClient(
     new SoapClient(BartecClient::WSDL_AUTH),
-    new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
+    new SoapClient(Version15Adapter::WSDL_COLLECTIVE_API), // v15
     'BARTEC_API_USERNAME',
     'BARTEC_API_PASSWORD'
 );
@@ -46,6 +47,7 @@ try {
 /** @var BartecService $bartecService */
 $bartecService = new BartecService(
     $bartecClient,
+    Version15Adapter::VERSION // v15
     // OPTIONAL: Any cache library implementing Psr\Cache\CacheItemPoolInterface
 );
 

--- a/src/Adapter/AbstractApiVersionAdapter.php
+++ b/src/Adapter/AbstractApiVersionAdapter.php
@@ -1,0 +1,338 @@
+<?php
+
+namespace LBHounslow\Bartec\Adapter;
+
+use LBHounslow\Bartec\Client\Client as BartecClient;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
+
+abstract class AbstractApiVersionAdapter implements ApiVersionAdapterInterface
+{
+    /**
+     * @var BartecClient
+     */
+    protected $bartecClient;
+
+    /**
+     * @param BartecClient $bartecClient
+     */
+    public function __construct(BartecClient $bartecClient)
+    {
+        $this->bartecClient = $bartecClient;
+    }
+
+    /**
+     * @return BartecClient
+     */
+    public function getBartecClient()
+    {
+        return $this->bartecClient;
+    }
+
+    /**
+     * @param array $soapOptions
+     * @return $this
+     */
+    public function setBartecClientSoapOptions(array $soapOptions)
+    {
+        $this->bartecClient->setSoapOptions($soapOptions);
+        return $this;
+    }
+
+    /**
+     * @param string $UPRN
+     * @param string $minimumDate
+     * @param string $maximumDate
+     * @param int $serviceTypeId
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequests(
+        string $UPRN,
+        string $minimumDate,
+        string $maximumDate,
+        int $serviceTypeId
+    ) {
+        return $this->bartecClient->call(
+            'ServiceRequests_Get',
+            [
+                'UPRNs' => ['decimal' => $UPRN],
+                'RequestDate' => [
+                    'MinimumDate' => $minimumDate,
+                    'MaximumDate' => $maximumDate,
+                ],
+                'ServiceTypes' => ['int' => $serviceTypeId],
+            ]
+        );
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequestClasses()
+    {
+        return $this->bartecClient->call('ServiceRequests_Classes_Get');
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequestTypes()
+    {
+        return $this->bartecClient->call('ServiceRequests_Types_Get');
+    }
+
+    /**
+     * @param int $serviceRequestClassId
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequestTypesByServiceRequestClassId(int $serviceRequestClassId)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequests_Types_Get',
+            ['ServiceRequestClass' => $serviceRequestClassId]
+        );
+    }
+
+    /**
+     * @param int $ServiceTypeID
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequestStatusForServiceTypeIdByStatus(int $ServiceTypeID)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequests_Statuses_Get',
+            ['ServiceTypeID' => $ServiceTypeID]
+        );
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceNoteTypeFromNoteTypeDescription()
+    {
+        return $this->bartecClient->call('ServiceRequests_Notes_Types_Get');
+    }
+
+    /**
+     * @param string $UPRN
+     * @return Response
+     * @throws SoapException
+     */
+    public function getPremisesByUPRN(string $UPRN)
+    {
+        return $this->bartecClient->call(
+            'Premises_Get',
+            ['UPRN' => $UPRN]
+        );
+    }
+
+    /**
+     * @param string $UPRN
+     * @return Response
+     * @throws SoapException
+     */
+    public function getPremisesDetailByUPRN(string $UPRN)
+    {
+        return $this->bartecClient->call(
+            'Premises_Detail_Get',
+            ['UPRN' => $UPRN]
+        );
+    }
+
+    /**
+     * @param string $UPRN
+     * @return Response
+     * @throws SoapException
+     */
+    public function getPremisesAttributes(string $UPRN)
+    {
+        return $this->bartecClient->call(
+            'Premises_Attributes_Get',
+            ['UPRN' => $UPRN]
+        );
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getCrews()
+    {
+        return $this->bartecClient->call('Crews_Get');
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequestSLAs()
+    {
+        return $this->bartecClient->call('ServiceRequests_SLAs_Get');
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceLandTypes()
+    {
+        return $this->bartecClient->call('System_LandTypes_Get');
+    }
+
+    /**
+     * @param string $UPRN
+     * @param string $minimumDate
+     * @param string $maximumDate
+     * @param bool $includeRelated
+     * @param null $workPackID
+     * @return Response
+     * @throws SoapException
+     */
+    public function getJobs(
+        string $UPRN,
+        string $minimumDate,
+        string $maximumDate,
+        bool $includeRelated = true,
+               $workPackID = null
+    ) {
+        $data = [
+            'UPRN' => $UPRN,
+            'WorkPackID' => $workPackID,
+            'ScheduleStart' => [
+                'MinimumDate' => $minimumDate,
+                'MaximumDate' => $maximumDate,
+            ],
+            'IncludeRelated' => ''
+        ];
+
+        if ($includeRelated) {
+            $data['IncludeRelated'] = 1;
+        }
+
+        return $this->bartecClient->call(
+            'Jobs_Get',
+            $data
+        );
+    }
+
+    /**
+     * @param int $jobId
+     * @return Response
+     * @throws SoapException
+     */
+    public function getJobDetail(int $jobId)
+    {
+        return $this->bartecClient->call(
+            'Jobs_Detail_Get',
+            ['jobID' => $jobId]
+        );
+    }
+
+    /**
+     * @param string $UPRN
+     * @param string $minimumDate
+     * @param string $maximumDate
+     * @param bool $includeRelated
+     * @param null $workpack
+     * @return Response
+     * @throws SoapException
+     */
+    public function getEventsByUPRN(
+        string $UPRN,
+        string $minimumDate = '',
+        string $maximumDate = '',
+        bool $includeRelated = true,
+               $workpack = null
+    ) {
+        $data = [
+            'UPRN' => $UPRN,
+            'WorkPack' => $workpack,
+            'IncludeRelated' => ''
+        ];
+
+        if ($minimumDate) {
+            $data['DateRange']['MinimumDate'] = $minimumDate;
+        }
+
+        if ($maximumDate) {
+            $data['DateRange']['MaximumDate'] = $maximumDate;
+        }
+
+        if ($includeRelated) {
+            $data['IncludeRelated'] = 1;
+        }
+
+        return $this->bartecClient->call(
+            'Premises_Events_Get',
+            $data
+        );
+    }
+
+    /**
+     * @param string $UPRN
+     * @param bool $includeRelated
+     * @return Response
+     * @throws SoapException
+     */
+    public function getFeatures(string $UPRN, bool $includeRelated = true)
+    {
+        $data = [
+            'UPRN' => $UPRN,
+            'IncludeRelated' => '',
+            'Types' => '',
+            'Statuses' => '',
+            'Manufacturers' => '',
+            'Colours' => '',
+            'Conditions' => '',
+            'WasteTypes' => ''
+        ];
+
+        if ($includeRelated) {
+            $data['IncludeRelated'] = 1;
+        }
+
+        return $this->bartecClient->call(
+            'Features_Get',
+            $data
+        );
+    }
+
+    /**
+     * @return Response
+     * @throws SoapException
+     */
+    public function getFeatureTypes()
+    {
+        return $this->bartecClient->call(
+            'Features_Types_Get'
+        );
+    }
+
+    /**
+     * @param string $UPRN
+     * @return Response
+     * @throws SoapException
+     */
+    public function getFeatureSchedules(string $UPRN)
+    {
+        return $this->bartecClient->call(
+            'Features_Schedules_Get',
+            ['UPRN' => $UPRN, 'Types' => '']
+        );
+    }
+
+    /**
+     * @param string $serviceRequestCode
+     * @return int
+     */
+    public function getNumericIDFromServiceRequestCode(string $serviceRequestCode)
+    {
+        return (int) str_replace('SR', '', $serviceRequestCode);
+    }
+}

--- a/src/Adapter/ApiVersionAdapterInterface.php
+++ b/src/Adapter/ApiVersionAdapterInterface.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace LBHounslow\Bartec\Adapter;
+
+use LBHounslow\Bartec\Client\Client as BartecClient;
+use LBHounslow\Bartec\Exception\SoapException;
+use LBHounslow\Bartec\Response\Response;
+
+interface ApiVersionAdapterInterface
+{
+    /**
+     * @return BartecClient
+     */
+    public function getBartecClient();
+
+    /**
+     * @param array $soapOptions
+     * @return $this
+     */
+    public function setBartecClientSoapOptions(array $soapOptions);
+
+    /**
+     * @param array $data
+     * @return Response
+     * @throws SoapException
+     */
+    public function createServiceRequest(array $data);
+
+    /**
+     * @param string $serviceRequestCode
+     * @param array $data
+     * @return Response
+     * @throws SoapException
+     */
+    public function updateServiceRequest(string $serviceRequestCode, array $data);
+
+    /**
+     * @param string $ServiceRequestCode
+     * @return Response
+     * @throws SoapException
+     */
+    public function getServiceRequestDetail(string $ServiceRequestCode);
+
+    /**
+     * @param \stdClass $ServiceRequest
+     * @param \stdClass $ServiceRequestStatus
+     * @return Response
+     * @throws SoapException
+     */
+    public function setServiceRequestStatus(\stdClass $ServiceRequest, \stdClass $ServiceRequestStatus);
+
+    /**
+     * @param array $data
+     * @return Response
+     * @throws SoapException
+     */
+    public function createServiceRequestDocument(array $data);
+
+    /**
+     * @param int $ServiceRequestID
+     * @param string $note
+     * @param int $noteTypeID
+     * @param int $sequenceNumber
+     * @param string $comment
+     * @return Response
+     * @throws SoapException
+     */
+    public function createServiceRequestNote(int $ServiceRequestID, string $note, int $noteTypeID, $sequenceNumber = 1, $comment = '');
+}

--- a/src/Adapter/Version15Adapter.php
+++ b/src/Adapter/Version15Adapter.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace LBHounslow\Bartec\Adapter;
+
+use LBHounslow\Bartec\Enum\BartecServiceEnum;
+
+class Version15Adapter extends AbstractApiVersionAdapter
+{
+    const VERSION = 'v15';
+    const WSDL_COLLECTIVE_API = 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx?WSDL';
+
+    /**
+     * @inheritdoc
+     */
+    public function createServiceRequest(array $data)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequests_Create',
+            $data
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function updateServiceRequest(string $serviceRequestCode, array $data)
+    {
+        $data['serviceCode'] = $serviceRequestCode;
+
+        if (empty($data['serviceLocationDescription'])) { // workaround for issue in Bartec API
+            $data['serviceLocationDescription'] = '';
+        }
+
+        return $this->bartecClient->call(
+            'ServiceRequests_Update',
+            $data
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getServiceRequestDetail(string $ServiceRequestCode)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequests_Detail_Get',
+            ['ServiceCode' => $ServiceRequestCode]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setServiceRequestStatus(\stdClass $ServiceRequest, \stdClass $ServiceRequestStatus)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequests_Status_Set',
+            [
+                'ServiceCode' => $ServiceRequest->ServiceCode,
+                'StatusID' => $ServiceRequestStatus->ID,
+                'Comments' => BartecServiceEnum::DEFAULT_NOTE_COMMENT,
+            ]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createServiceRequestDocument(array $data)
+    {
+        return $this->bartecClient->call('Service_Request_Document_Create', $data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createServiceRequestNote(
+        int $ServiceRequestID,
+        string $note,
+        int $noteTypeID,
+        $sequenceNumber = 1,
+        $comment = ''
+    ) {
+        return $this->bartecClient->call(
+            'ServiceRequests_Notes_Create',
+            [
+                'ServiceRequestID' => $ServiceRequestID,
+                'ServiceCode' => null,
+                'NoteTypeID' => $noteTypeID,
+                'Note' => $note,
+                'Comment' => $comment,
+                'SequenceNumber' => $sequenceNumber
+            ]
+        );
+    }
+}

--- a/src/Adapter/Version16Adapter.php
+++ b/src/Adapter/Version16Adapter.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace LBHounslow\Bartec\Adapter;
+
+use LBHounslow\Bartec\Enum\BartecServiceEnum;
+
+class Version16Adapter extends AbstractApiVersionAdapter
+{
+    const VERSION = 'v16';
+    const WSDL_COLLECTIVE_API = 'https://collectiveapi.bartec-systems.com/API-R1604/CollectiveAPI.asmx?WSDL';
+
+    /**
+     * @inheritdoc
+     */
+    public function createServiceRequest(array $data)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequest_Create',
+            $data
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function updateServiceRequest(string $serviceRequestCode, array $data)
+    {
+        $data['serviceCode'] = $serviceRequestCode;
+        $data['SR_ID'] = $this->getNumericIDFromServiceRequestCode($serviceRequestCode);
+
+        if (empty($data['serviceLocationDescription'])) { // workaround for issue in Bartec API
+            $data['serviceLocationDescription'] = '';
+        }
+
+        return $this->bartecClient->call(
+            'ServiceRequest_Update',
+            $data
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getServiceRequestDetail(string $ServiceRequestCode)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequests_Detail_Get',
+            ['ServiceCodes' => [$ServiceRequestCode]]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function setServiceRequestStatus(\stdClass $ServiceRequest, \stdClass $ServiceRequestStatus)
+    {
+        return $this->bartecClient->call(
+            'ServiceRequest_Status_Set',
+            [
+                'ServiceCode' => $ServiceRequest->ServiceCode,
+                'StatusID' => $ServiceRequestStatus->ID,
+                'Comments' => BartecServiceEnum::DEFAULT_NOTE_COMMENT,
+            ]
+        );
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createServiceRequestDocument(array $data)
+    {
+        return $this->bartecClient->call('ServiceRequest_Document_Create', $data);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function createServiceRequestNote(
+        int $ServiceRequestID,
+        string $note,
+        int $noteTypeID,
+        $sequenceNumber = 1,
+        $comment = ''
+    ) {
+        return $this->bartecClient->call(
+            'ServiceRequest_Note_Create',
+            [
+                'ServiceRequestID' => $ServiceRequestID,
+                'ServiceCode' => null,
+                'NoteTypeID' => $noteTypeID,
+                'Note' => $note,
+                'Comment' => $comment,
+                'SequenceNumber' => $sequenceNumber
+            ]
+        );
+    }
+}

--- a/src/Adapter/Version16Adapter.php
+++ b/src/Adapter/Version16Adapter.php
@@ -14,6 +14,12 @@ class Version16Adapter extends AbstractApiVersionAdapter
      */
     public function createServiceRequest(array $data)
     {
+        // Correct any v15 service requests with the old extended data field
+        if (isset($data['extendedData']['ServiceRequests_CreateServiceRequests_CreateFields'])) {
+            $data['extendedData']['ServiceRequest_CreateServiceRequest_CreateFields'] = $data['extendedData']['ServiceRequests_CreateServiceRequests_CreateFields'];
+            unset($data['extendedData']['ServiceRequests_CreateServiceRequests_CreateFields']);
+        }
+
         return $this->bartecClient->call(
             'ServiceRequest_Create',
             $data

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -8,7 +8,6 @@ use LBHounslow\Bartec\Response\Response;
 class Client
 {
     public const WSDL_AUTH = 'https://collectiveapi.bartec-systems.com/Auth/Authenticate.asmx?WSDL';
-    public const WSDL_COLLECTIVE_API_V15 = 'https://collectiveapi.bartec-systems.com/API-R1531/CollectiveAPI.asmx?WSDL';
 
     /**
      * @var SoapClient

--- a/src/Service/BartecService.php
+++ b/src/Service/BartecService.php
@@ -23,8 +23,8 @@ class BartecService
     const CACHE_NAMESPACE = 'lb-hounslow/bartec';
 
     const VERSION_ADAPTERS = [
-        'v15' => Version15Adapter::class,
-        'v16' => Version16Adapter::class
+        Version15Adapter::VERSION => Version15Adapter::class,
+        Version16Adapter::VERSION => Version16Adapter::class
     ];
 
     /**

--- a/src/Service/BartecService.php
+++ b/src/Service/BartecService.php
@@ -2,6 +2,9 @@
 
 namespace LBHounslow\Bartec\Service;
 
+use LBHounslow\Bartec\Adapter\ApiVersionAdapterInterface;
+use LBHounslow\Bartec\Adapter\Version15Adapter;
+use LBHounslow\Bartec\Adapter\Version16Adapter;
 use LBHounslow\Bartec\Client\Client as BartecClient;
 use LBHounslow\Bartec\Enum\BartecServiceEnum;
 use LBHounslow\Bartec\Exception\SoapException;
@@ -19,10 +22,15 @@ class BartecService
     const CACHE_LIFETIME = 3600; // 1 hour
     const CACHE_NAMESPACE = 'lb-hounslow/bartec';
 
+    const VERSION_ADAPTERS = [
+        'v15' => Version15Adapter::class,
+        'v16' => Version16Adapter::class
+    ];
+
     /**
-     * @var BartecClient
+     * @var ApiVersionAdapterInterface
      */
-    protected $client;
+    protected $apiVersionAdapter;
 
     /**
      * @var CacheItemPoolInterface|null
@@ -30,13 +38,34 @@ class BartecService
     protected $cache;
 
     /**
-     * @param BartecClient $client
+     * @param BartecClient $bartecClient
+     * @param string $version
      * @param CacheItemPoolInterface|null $cache
      */
-    public function __construct(BartecClient $client, CacheItemPoolInterface $cache = null)
-    {
-        $this->client = $client;
+    public function __construct(
+        BartecClient $bartecClient,
+        string $version,
+        CacheItemPoolInterface $cache = null
+    ) {
+        $this->apiVersionAdapter = $this->factoryApiVersionAdapter($bartecClient, $version);
         $this->cache = $cache;
+    }
+
+    /**
+     * @param BartecClient $bartecClient
+     * @param string $version
+     * @return ApiVersionAdapterInterface
+     * @throws \InvalidArgumentException
+     */
+    public function factoryApiVersionAdapter(BartecClient $bartecClient, string $version)
+    {
+        if (!in_array($version, array_keys(self::VERSION_ADAPTERS))) {
+            throw new \InvalidArgumentException(sprintf("Version '%s' is not supported", $version));
+        }
+
+        $versionAdapterClass = self::VERSION_ADAPTERS[$version];
+
+        return new $versionAdapterClass($bartecClient);
     }
 
     /**
@@ -44,7 +73,7 @@ class BartecService
      */
     public function getClient()
     {
-        return $this->client;
+        return $this->apiVersionAdapter->getBartecClient();
     }
 
     /**
@@ -53,7 +82,8 @@ class BartecService
      */
     public function setClientSoapOptions(array $soapOptions)
     {
-        $this->client->setSoapOptions($soapOptions);
+        $this->apiVersionAdapter->getBartecClient()
+            ->setSoapOptions($soapOptions);
         return $this;
     }
 
@@ -64,10 +94,8 @@ class BartecService
      */
     public function createServiceRequest(array $data)
     {
-        $response = $this->client->call(
-            'ServiceRequests_Create',
-            $data
-        );
+        $response = $this->apiVersionAdapter
+            ->createServiceRequest($data);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -79,20 +107,13 @@ class BartecService
     /**
      * @param string $serviceRequestCode
      * @param array $data
-     * @return \stdClass|null
+     * @return mixed|null
      * @throws SoapException
      */
     public function updateServiceRequest(string $serviceRequestCode, array $data)
     {
-        $data['serviceCode'] = $serviceRequestCode;
-        if (empty($data['serviceLocationDescription'])) { // workaround for issue in Bartec API
-            $data['serviceLocationDescription'] = '';
-        }
-
-        $response = $this->client->call(
-            'ServiceRequests_Update',
-            $data
-        );
+        $response = $this->apiVersionAdapter
+            ->updateServiceRequest($serviceRequestCode, $data);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -115,17 +136,13 @@ class BartecService
         string $maximumDate,
         int $serviceTypeId
     ) {
-        $response = $this->client->call(
-            'ServiceRequests_Get',
-            [
-                'UPRNs' => ['decimal' => $UPRN],
-                'RequestDate' => [
-                    'MinimumDate' => $minimumDate,
-                    'MaximumDate' => $maximumDate,
-                ],
-                'ServiceTypes' => ['int' => $serviceTypeId],
-            ]
-        );
+        $response = $this->apiVersionAdapter
+            ->getServiceRequests(
+                $UPRN,
+                $minimumDate,
+                $maximumDate,
+                $serviceTypeId
+            );
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -141,10 +158,8 @@ class BartecService
      */
     public function getServiceRequestDetail(string $ServiceRequestCode)
     {
-        $response = $this->client->call(
-            'ServiceRequests_Detail_Get',
-            ['ServiceCode' => $ServiceRequestCode]
-        );
+        $response = $this->apiVersionAdapter
+            ->getServiceRequestDetail($ServiceRequestCode);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -162,14 +177,8 @@ class BartecService
     public function setServiceRequestStatus(\stdClass $ServiceRequest, \stdClass $ServiceRequestStatus)
     {
         /** @var Response $response */
-        $response = $this->client->call(
-            'ServiceRequests_Status_Set',
-            [
-                'ServiceCode' => $ServiceRequest->ServiceCode,
-                'StatusID' => $ServiceRequestStatus->ID,
-                'Comments' => BartecServiceEnum::DEFAULT_NOTE_COMMENT,
-            ]
-        );
+        $response = $this->apiVersionAdapter
+            ->setServiceRequestStatus($ServiceRequest, $ServiceRequestStatus);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -195,17 +204,14 @@ class BartecService
         $comment = ''
     ) {
         /** @var Response $response */
-        $response = $this->client->call(
-            'ServiceRequests_Notes_Create',
-            [
-                'ServiceRequestID' => $ServiceRequestID,
-                'ServiceCode' => null,
-                'NoteTypeID' => $noteTypeID,
-                'Note' => $note,
-                'Comment' => $comment,
-                'SequenceNumber' => $sequenceNumber
-            ]
-        );
+        $response = $this->apiVersionAdapter
+            ->createServiceRequestNote(
+                $ServiceRequestID,
+                $note,
+                $noteTypeID,
+                $sequenceNumber,
+                $comment
+            );
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -230,7 +236,8 @@ class BartecService
 
             if (!$cacheItem->isHit()) {
                 /** @var Response $response */
-                $response = $this->client->call('ServiceRequests_Classes_Get');
+                $response = $this->apiVersionAdapter
+                    ->getServiceRequestClasses();
 
                 if ($response->hasErrors()) {
                     throw new SoapException($response);
@@ -246,7 +253,8 @@ class BartecService
             $response = $cacheItem->get();
         } else {
             /** @var Response $response */
-            $response = $this->client->call('ServiceRequests_Classes_Get');
+            $response = $this->apiVersionAdapter
+                ->getServiceRequestClasses();
 
             if ($response->hasErrors()) {
                 throw new SoapException($response);
@@ -272,7 +280,8 @@ class BartecService
 
             if (!$cacheItem->isHit()) {
                 /** @var Response $response */
-                $response = $this->client->call('ServiceRequests_Types_Get');
+                $response = $this->apiVersionAdapter
+                    ->getServiceRequestTypes();
 
                 if ($response->hasErrors()) {
                     throw new SoapException($response);
@@ -288,7 +297,8 @@ class BartecService
             $response = $cacheItem->get();
         } else {
             /** @var Response $response */
-            $response = $this->client->call('ServiceRequests_Types_Get');
+            $response = $this->apiVersionAdapter
+                ->getServiceRequestTypes();
 
             if ($response->hasErrors()) {
                 throw new SoapException($response);
@@ -315,10 +325,8 @@ class BartecService
 
             if (!$cacheItem->isHit()) {
                 /** @var Response $response */
-                $response = $this->client->call(
-                    'ServiceRequests_Types_Get',
-                    ['ServiceRequestClass' => $serviceRequestClassId]
-                );
+                $response = $this->apiVersionAdapter
+                    ->getServiceRequestTypesByServiceRequestClassId($serviceRequestClassId);
 
                 if ($response->hasErrors()) {
                     throw new SoapException($response);
@@ -334,10 +342,8 @@ class BartecService
             $response = $cacheItem->get();
         } else {
             /** @var Response $response */
-            $response = $this->client->call(
-                'ServiceRequests_Types_Get',
-                ['ServiceRequestClass' => $serviceRequestClassId]
-            );
+            $response = $this->apiVersionAdapter
+                ->getServiceRequestTypesByServiceRequestClassId($serviceRequestClassId);
 
             if ($response->hasErrors()) {
                 throw new SoapException($response);
@@ -418,10 +424,8 @@ class BartecService
     public function getServiceRequestStatusForServiceTypeIdByStatus(int $ServiceTypeID, string $status)
     {
         /** @var Response $response */
-        $response = $this->client->call(
-            'ServiceRequests_Statuses_Get',
-            ['ServiceTypeID' => $ServiceTypeID]
-        );
+        $response = $this->apiVersionAdapter
+            ->getServiceRequestStatusForServiceTypeIdByStatus($ServiceTypeID);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -443,7 +447,8 @@ class BartecService
     public function getServiceNoteTypeFromNoteTypeDescription(string $noteTypeDescription)
     {
         /** @var Response $response */
-        $response = $this->client->call('ServiceRequests_Notes_Types_Get');
+        $response = $this->apiVersionAdapter
+            ->getServiceNoteTypeFromNoteTypeDescription();
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -465,7 +470,8 @@ class BartecService
     public function createServiceRequestDocument(array $data)
     {
         /** @var Response $response */
-        $response = $this->client->call('Service_Request_Document_Create', $data);
+        $response = $this->apiVersionAdapter
+            ->createServiceRequestDocument($data);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -480,10 +486,9 @@ class BartecService
      */
     public function getPremisesByUPRN(string $UPRN)
     {
-        $response = $this->client->call(
-            'Premises_Get',
-            ['UPRN' => $UPRN]
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getPremisesByUPRN($UPRN);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -499,10 +504,9 @@ class BartecService
      */
     public function getPremisesDetailByUPRN(string $UPRN)
     {
-        $response = $this->client->call(
-            'Premises_Detail_Get',
-            ['UPRN' => $UPRN]
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getPremisesDetailByUPRN($UPRN);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -518,10 +522,9 @@ class BartecService
      */
     public function getPremisesAttributes(string $UPRN)
     {
-        $response = $this->client->call(
-            'Premises_Attributes_Get',
-            ['UPRN' => $UPRN]
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getPremisesAttributes($UPRN);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -637,7 +640,7 @@ class BartecService
             if (!$cacheItem->isHit()) {
 
                 /** @var Response $response */
-                $response = $this->client->call('Crews_Get');
+                $response = $this->apiVersionAdapter->getCrews();
 
                 if ($response->hasErrors()) {
                     throw new SoapException($response);
@@ -653,7 +656,7 @@ class BartecService
             $response = $cacheItem->get();
         } else {
             /** @var Response $response */
-            $response = $this->client->call('Crews_Get');
+            $response = $this->apiVersionAdapter->getCrews();
 
             if ($response->hasErrors()) {
                 throw new SoapException($response);
@@ -687,7 +690,8 @@ class BartecService
             if (!$cacheItem->isHit()) {
 
                 /** @var Response $response */
-                $response = $this->client->call('ServiceRequests_SLAs_Get');
+                $response = $this->apiVersionAdapter
+                    ->getServiceRequestSLAs();
 
                 if ($response->hasErrors()) {
                     throw new SoapException($response);
@@ -703,7 +707,8 @@ class BartecService
             $response = $cacheItem->get();
         } else {
             /** @var Response $response */
-            $response = $this->client->call('ServiceRequests_SLAs_Get');
+            $response = $this->apiVersionAdapter
+                ->getServiceRequestSLAs();
 
             if ($response->hasErrors()) {
                 throw new SoapException($response);
@@ -737,7 +742,8 @@ class BartecService
             if (!$cacheItem->isHit()) {
 
                 /** @var Response $response */
-                $response = $this->client->call('System_LandTypes_Get');
+                $response = $this->apiVersionAdapter
+                    ->getServiceLandTypes();
 
                 if ($response->hasErrors()) {
                     throw new SoapException($response);
@@ -753,7 +759,8 @@ class BartecService
             $response = $cacheItem->get();
         } else {
             /** @var Response $response */
-            $response = $this->client->call('System_LandTypes_Get');
+            $response = $this->apiVersionAdapter
+                ->getServiceLandTypes();
 
             if ($response->hasErrors()) {
                 throw new SoapException($response);
@@ -785,24 +792,15 @@ class BartecService
         bool $includeRelated = true,
         $workPackID = null
     ) {
-        $data = [
-            'UPRN' => $UPRN,
-            'WorkPackID' => $workPackID,
-            'ScheduleStart' => [
-                'MinimumDate' => $minimumDate,
-                'MaximumDate' => $maximumDate,
-            ],
-            'IncludeRelated' => ''
-        ];
-
-        if ($includeRelated) {
-            $data['IncludeRelated'] = 1;
-        }
-
-        $response = $this->client->call(
-            'Jobs_Get',
-            $data
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getJobs(
+                $UPRN,
+                $minimumDate,
+                $maximumDate,
+                $includeRelated,
+                $workPackID
+            );
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -817,10 +815,10 @@ class BartecService
      * @throws SoapException
      */
     public function getJobDetail(int $jobId) {
-        $response = $this->client->call(
-            'Jobs_Detail_Get',
-            ['jobID' => $jobId]
-        );
+
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getJobDetail($jobId);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -845,28 +843,15 @@ class BartecService
         bool $includeRelated = true,
         $workpack = null
     ) {
-        $data = [
-            'UPRN' => $UPRN,
-            'WorkPack' => $workpack,
-            'IncludeRelated' => ''
-        ];
-
-        if ($minimumDate) {
-            $data['DateRange']['MinimumDate'] = $minimumDate;
-        }
-
-        if ($maximumDate) {
-            $data['DateRange']['MaximumDate'] = $maximumDate;
-        }
-
-        if ($includeRelated) {
-            $data['IncludeRelated'] = 1;
-        }
-
-        $response = $this->client->call(
-            'Premises_Events_Get',
-            $data
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getEventsByUPRN(
+                $UPRN,
+                $minimumDate,
+                $maximumDate,
+                $includeRelated,
+                $workpack
+            );
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -908,25 +893,9 @@ class BartecService
      */
     public function getFeatures(string $UPRN, bool $includeRelated = true)
     {
-        $data = [
-            'UPRN' => $UPRN,
-            'IncludeRelated' => '',
-            'Types' => '',
-            'Statuses' => '',
-            'Manufacturers' => '',
-            'Colours' => '',
-            'Conditions' => '',
-            'WasteTypes' => ''
-        ];
-
-        if ($includeRelated) {
-            $data['IncludeRelated'] = 1;
-        }
-
-        $response = $this->client->call(
-            'Features_Get',
-            $data
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getFeatures($UPRN, $includeRelated);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -941,9 +910,9 @@ class BartecService
      */
     public function getFeatureTypes()
     {
-        $response = $this->client->call(
-            'Features_Types_Get'
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getFeatureTypes();
 
         if ($response->hasErrors()) {
             throw new SoapException($response);
@@ -959,10 +928,9 @@ class BartecService
      */
     public function getFeatureSchedules(string $UPRN)
     {
-        $response = $this->client->call(
-            'Features_Schedules_Get',
-            ['UPRN' => $UPRN, 'Types' => '']
-        );
+        /** @var Response $response */
+        $response = $this->apiVersionAdapter
+            ->getFeatureSchedules($UPRN);
 
         if ($response->hasErrors()) {
             throw new SoapException($response);

--- a/tests/functional/Service/BartecServiceTest.php
+++ b/tests/functional/Service/BartecServiceTest.php
@@ -35,6 +35,29 @@ class BartecServiceTest extends BartecTestCase
         parent::setUp();
     }
 
+    public function testThatGetClientReturnsBartecClient()
+    {
+        $result = $this->bartecService->getClient();
+        $this->assertInstanceOf(BartecClient::class, $result);
+    }
+
+    public function testThatSetClientSoapOptionsStoresSoapOptionsInClient()
+    {
+        $soapOptions = [
+            'uri' => 'https://test.url',
+            'trace' => 1,
+            'connection_timeout' => 20
+        ];
+
+        $this->bartecService->setClientSoapOptions($soapOptions);
+
+        $authSoapClientOptions = $this->bartecService->getClient()->getCollectiveSoapClient()->getOptions();
+        $collectiveSoapClientOptions = $this->bartecService->getClient()->getCollectiveSoapClient()->getOptions();
+
+        $this->assertEquals($soapOptions, $authSoapClientOptions);
+        $this->assertEquals($soapOptions, $collectiveSoapClientOptions);
+    }
+
     public function testItGetsServiceRequestClasses()
     {
         /** @var Response $response */

--- a/tests/functional/Service/BartecServiceTest.php
+++ b/tests/functional/Service/BartecServiceTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Functional\Service;
 
-use LBHounslow\Bartec\Adapter\Version15Adapter;
+use LBHounslow\Bartec\Adapter\Version16Adapter;
 use LBHounslow\Bartec\Client\Client as BartecClient;
 use LBHounslow\Bartec\Client\SoapClient;
 use LBHounslow\Bartec\Enum\BartecServiceEnum;
@@ -24,12 +24,12 @@ class BartecServiceTest extends BartecTestCase
         $this->bartecService = new BartecService(
             new BartecClient(
                 new SoapClient(BartecClient::WSDL_AUTH),
-                new SoapClient(Version15Adapter::WSDL_COLLECTIVE_API), // v15
+                new SoapClient(Version16Adapter::WSDL_COLLECTIVE_API), // v16
                 'BARTEC_API_USERNAME',
                 'BARTEC_API_PASSWORD',
                 ['trace' => 1]
             ),
-            Version15Adapter::VERSION // v15
+            Version16Adapter::VERSION // v16
             // no cache passed for testing
         );
         parent::setUp();
@@ -302,62 +302,6 @@ class BartecServiceTest extends BartecTestCase
         $this->assertEquals($file->getFilename(), $ServiceRequestDetail->ServiceRequest->AttachedDocuments->AttachedDocument->DocumentName);
     }
 
-    public function createServiceRequestDataProvider()
-    {
-        $this->setUp();
-
-        /** @var \stdClass|null $ServiceRequestClass */
-        $ServiceRequestClass = $this->bartecService->getServiceRequestClassFromServiceRequestClassName(BartecServiceEnum::SERVICE_REQUEST_CLASS_NAME_GARDEN_WASTE);
-
-        /** @var \stdClass|null $ServiceRequestType */
-        $ServiceRequestType = $this->bartecService->getServiceRequestTypeFromServiceRequestClassIdAndServiceRequestTypeName(
-            $ServiceRequestClass->ID,
-            BartecServiceEnum::SERVICE_REQUEST_TYPE_NAME_SUBSCRIPTION
-        );
-
-        /** @var \stdClass|null $ServiceRequestStatus */
-        $ServiceRequestStatus = $this->bartecService->getServiceRequestStatusForServiceTypeIdByStatus(
-            $ServiceRequestType->ID,
-            BartecServiceEnum::STATUS_PENDING
-        );
-
-        return [
-            [
-                [
-                    'UPRN' => self::RESIDENTIAL_UPRN,
-                    'ServiceRequest_Location' => '',
-                    'serviceLocationDescription' => '',
-                    'DateRequested' => (new \DateTimeImmutable())->format(DateEnum::ISO8601_NO_TIMEZONE),
-                    'ServiceTypeID' => $ServiceRequestType->ID,
-                    'ServiceStatusID' => $ServiceRequestStatus->ID,
-                    'reporterContact' => [
-                        'Title' => self::REPORTER_TITLE,
-                        'Forename' => self::REPORTER_FORENAME,
-                        'OtherNames' => self::REPORTER_OTHERNAMES,
-                        'Surname' => self::REPORTER_SURNAME,
-                        'Email' => self::REPORTER_EMAIL,
-                        'Telephone' => self::REPORTER_TELEPHONE,
-                        'SpecialCommunicationNeeds' => self::REPORTER_SPECIAL_COMMUNICATION_NEEDS,
-                        'ExternalReference' => self::REPORTER_EXTERNAL_REFERENCE,
-                        'ReporterType' => BartecServiceEnum::REPORTER_TYPE_PUBLIC
-                    ],
-                    'reporterBusiness' => '',
-                    'source' => BartecServiceEnum::DEFAULT_SERVICE_REQUEST_SOURCE,
-                    'ExternalReference' => self::REPORTER_EXTERNAL_REFERENCE,
-                    'LandTypeID' => $ServiceRequestType->DefaultLandType->ID,
-                    'SLAID' => $ServiceRequestType->DefaultSLA->ID,
-                    'CrewID' => $ServiceRequestType->DefaultCrew->ID,
-                    'extendedData' => [
-                        'ServiceRequests_CreateServiceRequests_CreateFields' => self::GARDEN_WASTE_SUBSCRIPTION_EXTENDED_DATA
-                    ],
-                    'relatedServiceRequests' => '',
-                    'relatedPremises' => '',
-                ],
-                $ServiceRequestType
-            ]
-        ];
-    }
-
     public function testItGetsServiceRequestsForUPRNDateRangeAndServiceTypeID()
     {
         $minimumDate = date(DateEnum::Y_m_d, strtotime(DateEnum::YESTERDAY));
@@ -625,5 +569,61 @@ class BartecServiceTest extends BartecTestCase
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->bartecService->validateWasteContainerFeatureTypeNames(['Invalid']);
+    }
+
+    public function createServiceRequestDataProvider()
+    {
+        $this->setUp();
+
+        /** @var \stdClass|null $ServiceRequestClass */
+        $ServiceRequestClass = $this->bartecService->getServiceRequestClassFromServiceRequestClassName(BartecServiceEnum::SERVICE_REQUEST_CLASS_NAME_GARDEN_WASTE);
+
+        /** @var \stdClass|null $ServiceRequestType */
+        $ServiceRequestType = $this->bartecService->getServiceRequestTypeFromServiceRequestClassIdAndServiceRequestTypeName(
+            $ServiceRequestClass->ID,
+            BartecServiceEnum::SERVICE_REQUEST_TYPE_NAME_SUBSCRIPTION
+        );
+
+        /** @var \stdClass|null $ServiceRequestStatus */
+        $ServiceRequestStatus = $this->bartecService->getServiceRequestStatusForServiceTypeIdByStatus(
+            $ServiceRequestType->ID,
+            BartecServiceEnum::STATUS_PENDING
+        );
+
+        return [
+            [
+                [
+                    'UPRN' => self::RESIDENTIAL_UPRN,
+                    'ServiceRequest_Location' => '',
+                    'serviceLocationDescription' => '',
+                    'DateRequested' => (new \DateTimeImmutable())->format(DateEnum::ISO8601_NO_TIMEZONE),
+                    'ServiceTypeID' => $ServiceRequestType->ID,
+                    'ServiceStatusID' => $ServiceRequestStatus->ID,
+                    'reporterContact' => [
+                        'Title' => self::REPORTER_TITLE,
+                        'Forename' => self::REPORTER_FORENAME,
+                        'OtherNames' => self::REPORTER_OTHERNAMES,
+                        'Surname' => self::REPORTER_SURNAME,
+                        'Email' => self::REPORTER_EMAIL,
+                        'Telephone' => self::REPORTER_TELEPHONE,
+                        'SpecialCommunicationNeeds' => self::REPORTER_SPECIAL_COMMUNICATION_NEEDS,
+                        'ExternalReference' => self::REPORTER_EXTERNAL_REFERENCE,
+                        'ReporterType' => BartecServiceEnum::REPORTER_TYPE_PUBLIC
+                    ],
+                    'reporterBusiness' => '',
+                    'source' => BartecServiceEnum::DEFAULT_SERVICE_REQUEST_SOURCE,
+                    'ExternalReference' => self::REPORTER_EXTERNAL_REFERENCE,
+                    'LandTypeID' => $ServiceRequestType->DefaultLandType->ID,
+                    'SLAID' => $ServiceRequestType->DefaultSLA->ID,
+                    'CrewID' => $ServiceRequestType->DefaultCrew->ID,
+                    'extendedData' => [
+                        'ServiceRequests_CreateServiceRequests_CreateFields' => self::GARDEN_WASTE_SUBSCRIPTION_EXTENDED_DATA
+                    ],
+                    'relatedServiceRequests' => '',
+                    'relatedPremises' => '',
+                ],
+                $ServiceRequestType
+            ]
+        ];
     }
 }

--- a/tests/functional/Service/BartecServiceTest.php
+++ b/tests/functional/Service/BartecServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Functional\Service;
 
+use LBHounslow\Bartec\Adapter\Version15Adapter;
 use LBHounslow\Bartec\Client\Client as BartecClient;
 use LBHounslow\Bartec\Client\SoapClient;
 use LBHounslow\Bartec\Enum\BartecServiceEnum;
@@ -23,11 +24,12 @@ class BartecServiceTest extends BartecTestCase
         $this->bartecService = new BartecService(
             new BartecClient(
                 new SoapClient(BartecClient::WSDL_AUTH),
-                new SoapClient(BartecClient::WSDL_COLLECTIVE_API_V15),
+                new SoapClient(Version15Adapter::WSDL_COLLECTIVE_API), // v15
                 'BARTEC_API_USERNAME',
                 'BARTEC_API_PASSWORD',
                 ['trace' => 1]
-            )
+            ),
+            Version15Adapter::VERSION // v15
             // no cache passed for testing
         );
         parent::setUp();


### PR DESCRIPTION
Ticket: [APID-40](https://hounslow.atlassian.net/browse/APID-40) - Bartec Collective API Upgrade to v16

Added an API version adapter layer ([here](https://github.com/LBHounslow/bartec/tree/APID-40-collective-v16-upgrade/src/Adapter)) that will allow us to switch API versions easily without making changes to the [BartecService](https://github.com/LBHounslow/bartec/blob/APID-40-collective-v16-upgrade/src/Service/BartecService.php#L20) class.

There are now two API version adapter classes:
- [src/Adapter/Version15Adapter](https://github.com/LBHounslow/bartec/blob/APID-40-collective-v16-upgrade/src/Adapter/Version15Adapter.php#L7)
- [src/Adapter/Version16Adapter](https://github.com/LBHounslow/bartec/blob/APID-40-collective-v16-upgrade/src/Adapter/Version16Adapter.php#L7)

These version classes contain the differences between Bartec Collective v15 and v16. Any version specific methods should be part of these version classes. The methods common to both are part of [AbstractApiVersionAdapter](https://github.com/LBHounslow/bartec/blob/APID-40-collective-v16-upgrade/src/Adapter/AbstractApiVersionAdapter.php#L9).

The only change to the service is to **pass the version number** when instantiating the [BartecService](https://github.com/LBHounslow/bartec/blob/APID-40-collective-v16-upgrade/src/Service/BartecService.php#L20):

```
/** @var BartecService $bartecService */
$bartecService = new BartecService(
    $bartecClient,              // instance of BartecClient
    Version15Adapter::VERSION,  // version to use (v15 or v16)  <--------- here
    // Optional PSR-6 cache library
);
```

This version number will load the appropriate api version adapter using [this factory method](https://github.com/LBHounslow/bartec/blob/APID-40-collective-v16-upgrade/src/Service/BartecService.php#L60). Passing an unsupported version number will throw and exception.

Passing tests:
```
./vendor/bin/phpunit tests --colors
PHPUnit 9.5.13 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.25
Configuration: /Users/brett/Code/bartec/phpunit.xml.dist

................................................................. 65 / 71 ( 94%)
....                                                              71 / 71 (100%)

Time: 00:16.710, Memory: 82.00 MB

OK (71 tests, 135 assertions)
```