### PR TITLE
Hotfix - Added fix for Jobs_Detail_Get method in BartecService

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Changelog
 
+### Release v1.9.1 `18/02/2022`
+
+This release includes a fix for the `Jobs_Detail_Get` Collective API method.
+
+- Fixed bug in `AbstractApiVersionAdapter.getJobDetail` call.
+- Added functional test coverage for this method.
+
 ### Release v1.9 `02/02/2022`
 
 This release is in preparation for Hounslow switching from Bartec Collective v15 to v16.

--- a/src/Adapter/AbstractApiVersionAdapter.php
+++ b/src/Adapter/AbstractApiVersionAdapter.php
@@ -237,7 +237,7 @@ abstract class AbstractApiVersionAdapter implements ApiVersionAdapterInterface
     {
         return $this->bartecClient->call(
             'Jobs_Detail_Get',
-            ['jobID' => $jobId]
+            ['JobID' => $jobId]
         );
     }
 

--- a/tests/functional/BartecTestCase.php
+++ b/tests/functional/BartecTestCase.php
@@ -19,6 +19,9 @@ abstract class BartecTestCase extends TestCase
 
     const RESIDENTIAL_UPRN = '100021529122'; // 1 Oaks Avenue, Feltham, TW13 5JD
 
+    // If you need a job ID, in the Bartec Software go to Work Packs then click on any Job Name and grab the ID
+    const JOB_ID = 210143649;
+
     const GARDEN_WASTE_SUBSCRIPTION_EXTENDED_DATA = [
         [
             'FieldName' => 'SackOrBin',

--- a/tests/functional/Service/BartecServiceTest.php
+++ b/tests/functional/Service/BartecServiceTest.php
@@ -524,6 +524,14 @@ class BartecServiceTest extends BartecTestCase
         $this->assertEquals(0, $result->Errors->Result);
     }
 
+    public function testThatGetJobDetailReturnsJob()
+    {
+        $result = $this->bartecService->getJobDetail(self::JOB_ID);
+        $this->assertTrue(isset($result->Job->ID));
+        $this->assertEquals(self::JOB_ID, $result->Job->ID);
+        $this->assertEquals(1, $result->RecordCount);
+    }
+
     public function testGetsEventsByUPRN()
     {
         $minimumDate = date(DateEnum::Y_m_d, strtotime(DateEnum::YESTERDAY));


### PR DESCRIPTION
- Fixed bug in `AbstractApiVersionAdapter.getJobDetail` call.
- Added functional test coverage for this method.